### PR TITLE
Do not crash when no options are passed, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ or
 #### Android
 
 1. Open up `android/app/src/main/java/[...]/MainActivity.java`
-  - Add `import li.yunqi.RNSecureStoragePackage;` to the imports at the top of the file
+  - Add `import li.yunqi.rnsecurestorage.RNSecureStoragePackage;` to the imports at the top of the file
   - Add `new RNSecureStoragePackage()` to the list returned by the `getPackages()` method
 2. Append the following lines to `android/settings.gradle`:
   	```

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const defaultOptions = {
 }
 
 export default {
-  getItem(key, options) {
+  getItem(key, options = {}) {
     const finalOptions = {
       ...defaultOptions,
       ...options,
@@ -57,7 +57,7 @@ export default {
     }
     return RNSecureStorage.getItem(key, finalOptions)
   },
-  setItem(key, value, options) {
+  setItem(key, value, options = {}) {
     const finalOptions = {
       ...defaultOptions,
       ...options,
@@ -67,7 +67,7 @@ export default {
     }
     return RNSecureStorage.setItem(key, value, finalOptions)
   },
-  removeItem(key, options) {
+  removeItem(key, options = {}) {
     const finalOptions = {
       ...defaultOptions,
       ...options,
@@ -77,7 +77,7 @@ export default {
     }
     return RNSecureStorage.removeItem(key, finalOptions)
   },
-  getAllKeys(options) {
+  getAllKeys(options = {}) {
     const finalOptions = {
       ...defaultOptions,
       ...options,
@@ -90,7 +90,7 @@ export default {
   getSupportedBiometryType() {
     return RNSecureStorage.getSupportedBiometryType()
   },
-  canCheckAuthentication(options) {
+  canCheckAuthentication(options = {}) {
     const finalOptions = {
       ...defaultOptions,
       ...options,


### PR DESCRIPTION
Closes #5 

This way you can call: `.setItem(key, value)` without options and use the defaults.